### PR TITLE
Fix start query id

### DIFF
--- a/task_1/ground_truth.py
+++ b/task_1/ground_truth.py
@@ -21,7 +21,7 @@ def ParseGroundTruth(mainfile):
 
 	queries = []
 
-	idx = 1
+	idx = 0
 	for s in root.findall('Person'):
  		queries.append((idx, s.get('filename')))
  		idx += 1


### PR DESCRIPTION
The start query id must be 0. In the test xml file, the queries start in 0.